### PR TITLE
Add Action Alert Header

### DIFF
--- a/list.html
+++ b/list.html
@@ -107,10 +107,13 @@
                       {{#if photoUrl}}
                         <img style="width:150px; padding: 0px 15px 0px 0px" align="left" src="{{photoUrl}}" alt="Card image cap">
                       {{/if}}
+
+                      {{#if actionNotes}}
                       <p>
                         <h5>Action Alert!</h5>
                         <b>{{actionNotes}}</b>
                       </p>
+                      {{/if}}
                       {{#if yimbyMailerLink}}
                         <a class="btn btn-primary" target="_blank" href="{{yimbyMailerLink}}">
                           YIMBY Mailer

--- a/list.html
+++ b/list.html
@@ -107,7 +107,10 @@
                       {{#if photoUrl}}
                         <img style="width:150px; padding: 0px 15px 0px 0px" align="left" src="{{photoUrl}}" alt="Card image cap">
                       {{/if}}
-                      <p><b>{{actionNotes}}</b></p>
+                      <p>
+                        <h5>Action Alert!</h5>
+                        <b>{{actionNotes}}</b>
+                      </p>
                       {{#if yimbyMailerLink}}
                         <a class="btn btn-primary" target="_blank" href="{{yimbyMailerLink}}">
                           YIMBY Mailer


### PR DESCRIPTION
# Overview
This PR adds an "action alert" header.

## Why?

When you're new, it's hard to tell what's meant by "Action Alert" on the list of folks. It looks like the "Action Alert"s are descriptions. This helps make things more clear.

## Screenshots
<img width="737" alt="screen shot 2018-07-27 at 6 36 51 pm" src="https://user-images.githubusercontent.com/5942769/43351766-0dce4370-91cc-11e8-9cf2-ecdd7d0fdd4e.png">
